### PR TITLE
Adjust PS deletion cleanup order

### DIFF
--- a/frontend/static/js/modules/passagens/passagens.js
+++ b/frontend/static/js/modules/passagens/passagens.js
@@ -714,11 +714,12 @@ async function onNovaPS_Guard() {
             } else {
                 showSuccess('PS excluída com sucesso');
                 await searchPassagens();
-                togglePSForm(false);
                 currentPS = null;
-                setMainTab('consultas'); 
+                await subModules.notifyPSChange(null);
+                togglePSForm(false);
+                setMainTab('consultas');
             }
-            
+
         } catch (error) {
             showError('Erro ao excluir PS: ' + error.message);
         }


### PR DESCRIPTION
## Summary
- ensure PS deletion clears current state before updating the UI
- notify registered submodules of PS removal so they can reset themselves

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5ad0daae88328bbc53398f1bad56c